### PR TITLE
Unify API

### DIFF
--- a/TrueBorderlessWindow.pro
+++ b/TrueBorderlessWindow.pro
@@ -11,12 +11,10 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = TrueBorderlessWindow
 TEMPLATE = app
 
-
 SOURCES += main.cpp\
     widget.cpp
 
 HEADERS  += widget.h
-
 
 win32 {
     # Only include / compile these files on Windows
@@ -28,8 +26,9 @@ win32 {
         qwinwidget.h \
         winnativewindow.h
 
-    LIBS += "C:\Program Files\Microsoft SDKs\Windows\v7.1\Lib\dwmapi.lib" \
-            "C:\Program Files\Microsoft SDKs\Windows\v7.1\Lib\gdi32.lib"
+    LIBS += -L"C:\Program Files\Microsoft SDKs\Windows\v7.1\Lib" \
+        -ldwmapi \
+        -lgdi32
 }
 
 mac {
@@ -42,6 +41,5 @@ mac {
     # Additionally include Cocoa for OS X code
 
     LIBS += -framework Foundation -framework Cocoa
-    INCLUDEPATH += /System/Library/Frameworks/Foundation.framework/Versions/C/Headers \
-
+    INCLUDEPATH += /System/Library/Frameworks/Foundation.framework/Versions/C/Headers
 }

--- a/TrueBorderlessWindow.pro
+++ b/TrueBorderlessWindow.pro
@@ -28,7 +28,8 @@ win32 {
         qwinwidget.h \
         winnativewindow.h
 
-    LIBS += dwmapi.lib
+    LIBS += "C:\Program Files\Microsoft SDKs\Windows\v7.1\Lib\dwmapi.lib" \
+            "C:\Program Files\Microsoft SDKs\Windows\v7.1\Lib\gdi32.lib"
 }
 
 mac {

--- a/main.cpp
+++ b/main.cpp
@@ -38,34 +38,24 @@ int main(int argc, char *argv[])
 
     //On Windows, the widget needs to be encapsulated in a native window for frameless rendering
     //In this case, QWinWidget #includes "Widget.h", creates it, and adds it to a layout
-	QWinWidget qWinWidget(windowXPos, windowYPos, windowWidth, windowHeight);
-    qWinWidget.show();
+    QWinWidget w;
 
-    return app.exec();
+#else
+
+    //On OS X / Linux, the widget can handle everything itself so just create Widget as normal
+    Widget w;
 
 #endif
 
 #ifdef __APPLE__
 
-    //On OS X, the widget can handle everything itself so just create Widget as normal
-    Widget w;
-	w.setGeometry(windowXPos, windowYPos, windowWidth, windowHeight);
-
     //Then, hide the OS X title bar
     OSXHideTitleBar::HideTitleBar(w.winId());
 
-    w.show();
-    return app.exec();
+#endif
 
-#else
-
-    //Non-Windows Non-Apple platform
-    //Just create Widget as normal
-    Widget w;
     w.setGeometry(windowXPos, windowYPos, windowWidth, windowHeight);
 
     w.show();
     return app.exec();
-
-#endif
 }

--- a/main.cpp
+++ b/main.cpp
@@ -19,11 +19,7 @@ int main(int argc, char *argv[])
     //See this bug for more details on how to get this right: https://bugreports.qt.io/browse/QTBUG-44486#comment-327410
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-
-
     QApplication app(argc, argv);
-
-
 
     //A common feature is to save your app's geometry on close such that you can draw in the same place on relaunch
     //Thus this project supports specifying the X/Y/Width/Height in a cross-platform manner
@@ -32,7 +28,6 @@ int main(int argc, char *argv[])
     windowYPos = 100;
     windowWidth = 1024;
     windowHeight = 768;
-
 
 #ifdef _WIN32
 

--- a/qwinwidget.cpp
+++ b/qwinwidget.cpp
@@ -76,7 +76,7 @@
 */
 
 
-QWinWidget::QWinWidget(int x = 100, int y = 100, int width = 1024, int height = 768)
+QWinWidget::QWinWidget()
     : QWidget(nullptr),
       m_Layout(),
       p_Widget(nullptr),
@@ -86,10 +86,10 @@ QWinWidget::QWinWidget(int x = 100, int y = 100, int width = 1024, int height = 
 {
 
     //Create a native window and give it geometry values * devicePixelRatio for HiDPI support
-    p_ParentWinNativeWindow = new WinNativeWindow(x  * window()->devicePixelRatio()
-        , y * window()->devicePixelRatio()
-        , width * window()->devicePixelRatio()
-        , height * window()->devicePixelRatio());
+    p_ParentWinNativeWindow = new WinNativeWindow(1  * window()->devicePixelRatio()
+        , 1 * window()->devicePixelRatio()
+        , 1 * window()->devicePixelRatio()
+        , 1 * window()->devicePixelRatio());
 
 	//If you want to set a minimize size for your app, do so here
     //p_ParentWinNativeWindow->setMinimumSize(1024 * window()->devicePixelRatio(), 768 * window()->devicePixelRatio());
@@ -257,6 +257,11 @@ void QWinWidget::showCentered()
 {
     center();
     show();
+}
+
+void QWinWidget::setGeometry(int x, int y, int w, int h)
+{
+    p_ParentWinNativeWindow->setGeometry(x, y, w, h);
 }
 
 /*!

--- a/qwinwidget.h
+++ b/qwinwidget.h
@@ -61,12 +61,13 @@ class QWinWidget : public QWidget
 {
     Q_OBJECT
 public:
-    QWinWidget(int x, int y, int width, int height);
+    QWinWidget();
     ~QWinWidget();
 
     void show();
     void center();
     void showCentered();
+    void setGeometry(int x, int y, int w, int h);
 
     HWND getParentWindow() const;
 

--- a/winnativewindow.cpp
+++ b/winnativewindow.cpp
@@ -217,6 +217,11 @@ LRESULT CALLBACK WinNativeWindow::WndProc(HWND hWnd, UINT message, WPARAM wParam
     return DefWindowProc(hWnd, message, wParam, lParam);
 }
 
+void WinNativeWindow::setGeometry(const int x, const int y, const int width, const int height)
+{
+    MoveWindow(hWnd, x, y, width, height, 1);
+}
+
 void WinNativeWindow::setMinimumSize(const int width, const int height)
 {
     this->minimumSize.required = true;

--- a/winnativewindow.cpp
+++ b/winnativewindow.cpp
@@ -112,7 +112,7 @@ LRESULT CALLBACK WinNativeWindow::WndProc(HWND hWnd, UINT message, WPARAM wParam
         case WM_NCHITTEST:
         {
 
-            const LONG borderWidth = 16; //This value can be arbitrarily large as only intentionally-HTTRANSPARENT'd messages arrive here
+            const LONG borderWidth = 8; //This value can be arbitrarily large as only intentionally-HTTRANSPARENT'd messages arrive here
             RECT winrect;
             GetWindowRect(hWnd, &winrect);
             long x = GET_X_LPARAM(lParam);

--- a/winnativewindow.h
+++ b/winnativewindow.h
@@ -26,6 +26,7 @@ public:
     void setMaximumSize(const int width, const int height);
     int getMaximumHeight();
     int getMaximumWidth();
+    void setGeometry(const int x, const int y, const int width, const int height);
 
 
     HWND hWnd;


### PR DESCRIPTION
Currently Mac OS X and Linux use `setGeometry`, while Windows is using the initialiser to set size and position. Change the code a little bit in order to unify the API/methods.

Also, currently the code doesn't compile on Windows (because of the `ifdefs`). Fix that too.