### PR TITLE
fix issue #13 and add support for QWinWidget multi instance

### DIFF
--- a/TrueFramelessWindow.pro
+++ b/TrueFramelessWindow.pro
@@ -28,7 +28,8 @@ win32 {
 
     LIBS += -L"C:\Program Files\Microsoft SDKs\Windows\v7.1\Lib" \
         -ldwmapi \
-        -lgdi32
+        -lgdi32 \
+        -lUser32
 }
 
 mac {

--- a/qwinwidget.cpp
+++ b/qwinwidget.cpp
@@ -105,19 +105,7 @@ bool NativeEventFilter::nativeEventFilter(const QByteArray &eventType, void *mes
     //Only close if safeToClose clears()
     if (msg->message == WM_CLOSE)
     {
-        if (true /* put your check for it if it safe to close your app here */) //eg, does the user need to save a document
-        {
-            //Safe to close, so hide the parent window
-            ShowWindow(winWidget->m_ParentNativeWindowHandle, false);
-
-            //And then quit
-            QApplication::quit();
-        }
-        else
-        {
-            *result = 0; //Set the message to 0 to ignore it, and thus, don't actually close
-            return true;
-        }
+        //do nothing
     }
 
     //Double check WM_SIZE messages to see if the parent native window is maximized
@@ -302,7 +290,6 @@ QWinWidget::QWinWidget()
 
     //Send the parent native window a WM_SIZE message to update the widget size 
     SendMessage(m_ParentNativeWindowHandle, WM_SIZE, 0, 0);
-
 }
 
 
@@ -441,23 +428,19 @@ void QWinWidget::onMaximizeButtonClicked()
 
 void QWinWidget::onCloseButtonClicked()
 {
-    if(true /* put your check for it if it safe to close your app here */) //eg, does the user need to save a document
-    {
-		//Safe to close, so hide the parent window
-        ShowWindow(m_ParentNativeWindowHandle, false);
-
-		//And then quit
-        QApplication::quit();
-    }
-    else
-    {
-        //Do nothing, and thus, don't actually close the window
-    }
+    close();
 }
 
 /*!
     \reimp
 */
+
+void QWinWidget::closeEvent(QCloseEvent *event)
+{
+    //use closeEvent to check for it whether it is safe to close your app here or not
+    ShowWindow(m_ParentNativeWindowHandle, false);
+}
+
 bool QWinWidget::eventFilter(QObject *o, QEvent *e)
 {
     QWidget *w = (QWidget*)o;

--- a/qwinwidget.h
+++ b/qwinwidget.h
@@ -90,6 +90,7 @@ public slots:
     void onCloseButtonClicked();
 
 protected:
+    void closeEvent(QCloseEvent *event) override;
     void childEvent( QChildEvent *e ) override;
     bool eventFilter( QObject *o, QEvent *e ) override;
 

--- a/qwinwidget.h
+++ b/qwinwidget.h
@@ -53,9 +53,22 @@
 
 #include <QWidget>
 #include <QVBoxLayout>
+#include <QAbstractNativeEventFilter>
 
 #include "widget.h"
 #include "WinNativeWindow.h"
+
+class QWinWidget;
+
+class NativeEventFilter : public QAbstractNativeEventFilter
+{
+public:
+    explicit NativeEventFilter(QWinWidget *widget);
+    bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) override;
+
+private:
+    QWinWidget *winWidget;
+};
 
 class QWinWidget : public QWidget
 {
@@ -83,8 +96,6 @@ protected:
     bool focusNextPrevChild(bool next) override;
     void focusInEvent(QFocusEvent *e) override;
 
-    bool nativeEvent(const QByteArray &eventType, void *message, long *result) override;
-
 
 private:
     QVBoxLayout m_Layout;
@@ -104,7 +115,7 @@ private:
     void resetFocus();
 
 
-
+    friend class NativeEventFilter;
 };
 
 #endif // QWINWIDGET_H

--- a/winnativewindow.h
+++ b/winnativewindow.h
@@ -31,8 +31,8 @@ public:
 
     HWND hWnd;
 
-    static HWND childWindow;
-    static QWidget* childWidget;
+    HWND childWindow;
+    QWidget* childWidget;
 
 private:
 


### PR DESCRIPTION
when there is a widget that has a attribute Qt::WA_NativeWindow inside the mainwindow, QWinWidget will never receive any native event.
to fix this, install a native event filter for QWinWidget to force it to get the native event.